### PR TITLE
fix iOS 14 GroupInfo empty bug

### DIFF
--- a/iOS/TUIKitDemo/TUIKitDemo/Chat/GroupInfoController.m
+++ b/iOS/TUIKitDemo/TUIKitDemo/Chat/GroupInfoController.m
@@ -22,6 +22,7 @@
 #import "THelper.h"
 #import <ImSDK/ImSDK.h>
 
+
 @interface GroupInfoController () <TGroupInfoControllerDelegate>
 
 @end
@@ -33,6 +34,7 @@
     TUIGroupInfoController *info = [[TUIGroupInfoController alloc] init];
     info.groupId = _groupId;
     info.delegate = self;
+    info.view.frame = self.view.bounds;
     [self addChildViewController:info];
     [self.view addSubview:info.view];
     self.title = @"详细资料";


### PR DESCRIPTION
修复 Demo 在 iOS 14 点击群组详情空白